### PR TITLE
Change regex to match more cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(rawSource) {
 
     // regex to parse out the define block including
     // all dependencies
-    var DEFINE_REGEX = /define\(((.*\n)*)\)/;
+    var DEFINE_REGEX = /define\(\[[\s\S]*?\)/;
 
 
     // this function will be returned by the mocked module


### PR DESCRIPTION
Right now this regex only matches this format:

```javascript
define([
  'a',
  'b'
], function (
  a,
  b
) {
  ...
});
```

With this change it also handles:

```javascript
define([
  'a',
  'b'
], function (a, b) {
});
```

```javascript
define(['a', 'b'], function (a, b) {
});
```
and a lot more variations due to [\s\S]

also, it tries to match a `[` right after `define(` so it doesn't match cases without dependencies like:

```javascript
define(function(require, exports, module) {
  ...
}
```

and

```javascript
define({
    color: "black",
    size: "unisize"
});
```