### PR TITLE
Use babel to parse AST and generate source-maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 *.log
-
+node_modules

--- a/index.js
+++ b/index.js
@@ -29,7 +29,15 @@
  *
  */
 
-module.exports = function(rawSource) {
+var babel = require('babel-core');
+var transform = babel.transform;
+var traverse = babel.traverse;
+var types = babel.types;
+var transformFromAst = babel.transformFromAst;
+var template = babel.template;
+var injectorTemplate = require('./injectorTemplate');
+
+module.exports = function(rawSource, inputSourceMap) {
 
     if (this && this.cacheable) this.cacheable();
 
@@ -37,69 +45,37 @@ module.exports = function(rawSource) {
     // all dependencies
     var DEFINE_REGEX = /define\(\[[\s\S]*?\)/;
 
-
-    // this function will be returned by the mocked module
-    // and make sure we're able to mock dependencies by passing an
-    // object with dependency paths as keys and mocks as values
-    var injector = function (mocks) {
-
-        // Create a custom define method which the original module will
-        // use to resolve dependencies. If a mock is passed for a given path
-        // the mock will be used, otherwise the original dependency will be
-        // loaded.
-        var __define__ = function (paths, definition) {
-
-            var deps = [];
-
-            function relsoveDependency (path, index) {
-
-                index = index || 0;
-
-                if(mocks && mocks[path]) {
-                    deps.push(mocks[path])
-                } else {
-                    deps.push(originalDeps[index]);
-                }
-            }
-
-            if (paths) {
-                if(typeof paths === 'string') {
-                    relsoveDependency(paths);
-                } else {
-                    paths.forEach(relsoveDependency);
-                }
-            }
-
-            return definition.apply(this, deps);
-        }
-
-        return (function () {
-            __SOURCE_PLACEHOLDER__
-        })();
-    };
-
-    var output = [];
-
     // replace define() with __define__ in the original source so that our
     // altered __define__() method gets called
-    var source = rawSource.replace('define', 'return __define__');
+    var source = rawSource.replace('define', '__define__');
+    // get the original dependencies so that we can access them from the injector
+    var originalDefine = rawSource.match(DEFINE_REGEX)[0];
 
-    // convert the injector to a string and insert module source code
-    var injectorString = injector.toString().replace('__SOURCE_PLACEHOLDER__', source);
+    // the file should be a valid javascript before babel template can read it,
+    // so we replace original define directly on the string
+    var injector = injectorTemplate.replace('ORIGINAL_DEFINE', originalDefine);
 
-    // start with the original define block in order to retrieve all
-    // original dependencies
-    output.push(rawSource.match(DEFINE_REGEX)[0] + '{');
+    var ast = transform(source, {
+      babelrc: false,
+      code: false,
+      compact: false,
+      filename: this.resourcePath,
+    }).ast;
 
-    // write original dependencies to an array so that we can access them from
-    // the injector
-    output.push('var originalDeps = arguments;');
+    var wrapperModuleAst = types.file(types.program([
+      template(injector)({
+        SOURCE: ast
+      }),
+    ]));
 
-    // add the module wrapped and altered to worked with our injector
-    output.push('return ' + injectorString);
+    var transformed = transformFromAst(wrapperModuleAst, source, {
+      sourceMaps: this.sourceMap,
+      sourceFileName: this.resourcePath,
+      inputSourceMap,
+      babelrc: false,
+      compact: false,
+      filename: this.resourcePath,
+    });
 
-    // close define block
-    output.push('});');
-
-    return output.join('\n');
+    this.callback(null, transformed.code, transformed.map);
 };

--- a/injectorTemplate.js
+++ b/injectorTemplate.js
@@ -1,0 +1,41 @@
+module.exports = "ORIGINAL_DEFINE{ \
+    var originalDeps = arguments; \
+    return " + function (mocks) {
+
+      // Create a custom define method which the original module will
+      // use to resolve dependencies. If a mock is passed for a given path
+      // the mock will be used, otherwise the original dependency will be
+      // loaded.
+      var __defined_module__;
+      var __define__ = function (paths, definition) {
+
+          var deps = [];
+
+          function relsoveDependency (path, index) {
+
+              index = index || 0;
+
+              if(mocks && mocks[path]) {
+                  deps.push(mocks[path])
+              } else {
+                  deps.push(originalDeps[index]);
+              }
+          }
+
+          if (paths) {
+              if(typeof paths === 'string') {
+                  relsoveDependency(paths);
+              } else {
+                  paths.forEach(relsoveDependency);
+              }
+          }
+
+          __defined_module__ = definition.apply(this, deps);
+      }
+
+      return (function () {
+          SOURCE
+          return __defined_module__;
+      })();
+  }.toString() + "; \
+});";

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/vejersele/mock-loader/issues"
   },
-  "homepage": "https://github.com/vejersele/mock-loader#readme"
+  "homepage": "https://github.com/vejersele/mock-loader#readme",
+  "dependencies": {
+    "babel-core": "^6.24.1"
+  }
 }


### PR DESCRIPTION
Hello,

We were having problems with istanbul coverage when using mock-loader because it does not generate source-maps.

I've taken inspiration on [inject-loader](https://github.com/plasticine/inject-loader/blob/master/src/injectify.js) to implement this, it uses babel to generate the source-maps.

Unfortunately I got lazy and did not implement tests, I've only tested directly by running the tests on our application.

I believe this should be a minor version.

Cheers! 